### PR TITLE
Restored material list example and code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,17 @@ configure_file(config.h.cmake.in config.h)
 # This is pulled from the subrepo SoGui.
 add_subdirectory(Inventor/${Gui}/common)
 
+set(COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Inventor/${Gui}/common)
+
+configure_file(${COMMON_DIR}/SoAnyMaterialList.cpp.in ${CMAKE_BINARY_DIR}/src/Inventor/${Gui}/SoAnyMaterialList.cpp)
+configure_file(${COMMON_DIR}/SoAnyMaterialList.h.in ${CMAKE_BINARY_DIR}/src/Inventor/${Gui}/SoAnyMaterialList.h)
+configure_file(${COMMON_DIR}/SoGuiMaterialList.h.in ${CMAKE_BINARY_DIR}/src/Inventor/${Gui}/So${Gui}MaterialList.h)
+configure_file(${COMMON_DIR}/SoAnyMaterialListBuiltins.cpp.in ${CMAKE_BINARY_DIR}/src/Inventor/${Gui}/SoAnyMaterialListBuiltins.cpp)
+
+
 file(GLOB_RECURSE COMMON_HDRS ${CMAKE_CURRENT_BINARY_DIR}/*.h)
 file(GLOB_RECURSE COMMON_SRCS ${CMAKE_CURRENT_BINARY_DIR}/*.cpp)
+
 
 set(HDRS
   #Inventor/${Gui}/So${Gui}Clipboard.h               # added
@@ -28,7 +37,7 @@ set(SRCS
   Inventor/${Gui}/So${Gui}Component.cpp
   Inventor/${Gui}/So${Gui}GLWidget.cpp
   Inventor/${Gui}/So${Gui}GraphEditor.cpp #added
-  # Inventor/${Gui}/So${Gui}MaterialList.cpp #added
+  Inventor/${Gui}/So${Gui}MaterialList.cpp #added
   Inventor/${Gui}/So${Gui}Roster.cpp #added
   Inventor/${Gui}/devices/So${Gui}Device.cpp
   Inventor/${Gui}/devices/So${Gui}InputFocus.cpp
@@ -44,9 +53,10 @@ set(SRCS
 )
 
 file(GLOB_RECURSE COMMON_RESOURCES ${CMAKE_BINARY_DIR}/data/materials/*.h)
-
+include_directories(AFTER ${CMAKE_BINARY_DIR}/data)
 include_directories(${GTK2_INCLUDE_DIRS})
 include_directories(${GTK_GL2_INCLUDE_DIRS})
+
 
 if(HAVE_JOYSTICK_LINUX)
   list(APPEND HDRS Inventor/${Gui}/devices/So${Gui}LinuxJoystick.h)

--- a/test-code/components/CMakeLists.txt
+++ b/test-code/components/CMakeLists.txt
@@ -1,3 +1,5 @@
 executable(graphed SOURCES graphed.cpp computils.cpp LIBS SoGtk)
 
 executable(planeviewer  SOURCES planeviewer.cpp computils.cpp LIBS SoGtk)
+
+executable(materiallist  SOURCES materiallist.cpp LIBS SoGtk)

--- a/test-code/components/materiallist.cpp
+++ b/test-code/components/materiallist.cpp
@@ -1,0 +1,55 @@
+/**************************************************************************\
+ * Copyright (c) Kongsberg Oil & Gas Technologies AS
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+\**************************************************************************/
+
+#include <Inventor/Gtk/SoGtk.h>
+#include <Inventor/Gtk/SoGtkMaterialList.h>
+
+// *************************************************************************
+
+int
+main(
+  int argc,
+  char ** argv )
+{
+  GtkWidget * window = SoGtk::init( argv[0] );
+
+  SoGtkMaterialList * grapheditor = new SoGtkMaterialList;
+  grapheditor->show();
+
+  SoGtk::mainLoop();
+
+  delete grapheditor;
+
+  return 0;
+} // main()
+
+// *************************************************************************


### PR DESCRIPTION
Hello,
this pull request requires soanydata, otherwise error on compilation will occur.
Material list widget has been re-added to the examples.